### PR TITLE
Fix: Correctly handle joining room not previously synced

### DIFF
--- a/syncapi/streams/stream_pdu.go
+++ b/syncapi/streams/stream_pdu.go
@@ -229,6 +229,11 @@ func (p *PDUStreamProvider) addRoomDeltaToResponse(
 		// This is all "okay" assuming history_visibility == "shared" which it is by default.
 		r.To = delta.MembershipPos
 	}
+	// if we joined in between sync calls, send reset From to simulate a complete sync
+	if delta.Membership == gomatrixserverlib.Join && delta.MembershipPos <= r.To && delta.MembershipPos > r.From {
+		r.From = 0
+	}
+
 	recentStreamEvents, limited, err := p.DB.RecentEvents(
 		ctx, delta.RoomID, r,
 		eventFilter, true, true,


### PR DESCRIPTION
Mostly making this PR to see if I can flush out the intended behavior.

Test Plan:
register new account bob
bob creates public, shared history room
bob sends a “hello world” message to the room
register new account jane
jane joins bobs room via room id

ISSUE:
Jane only sees her new membership event, doesn’t sync the name of the room, or bobs “hello world” message

NOTE: this happens any time jane syncs something after bob sends "hello world"
 then joins the room. All that's needed is a more recent FROM offset for Jane
to miss important information about the room

FIX
If a join event happened during a current sync delta, reset the to parameter to sync the entire room to Jane

Signed-off-by: `Austin Ellis <austin@hntlabs.com>`