### PR TITLE
Tak/remove-nonce-param

### DIFF
--- a/clientapi/auth/login_publickey_test.go
+++ b/clientapi/auth/login_publickey_test.go
@@ -61,7 +61,6 @@ func TestLoginPublicKeyNewSession(t *testing.T) {
 		"err.Code actual: %v, expected: %v", err.Code, http.StatusUnauthorized)
 	challenge := err.JSON.(Challenge)
 	assert.NotEmptyf(challenge.Session, "challenge.Session")
-	assert.NotEmptyf(challenge.Completed, "challenge.Completed")
 	assert.Truef(
 		authtypes.LoginTypePublicKeyEthereum == challenge.Flows[0].Stages[0],
 		"challenge.Flows[0].Stages[0] actual: %v, expected: %v", challenge.Flows[0].Stages[0], authtypes.LoginTypePublicKeyEthereum)
@@ -74,7 +73,6 @@ func TestLoginPublicKeyNewSession(t *testing.T) {
 		"[object]")
 	ethParams := params.(config.EthereumAuthParams)
 	assert.NotEmptyf(ethParams.ChainIDs, "ChainIDs actual: empty, expected not empty")
-	assert.NotEmptyf(ethParams.Nonce, "Nonce actual: \"\", expected: not empty")
 	assert.NotEmptyf(ethParams.Version, "Version actual: \"\", expected: not empty")
 }
 

--- a/clientapi/auth/user_interactive.go
+++ b/clientapi/auth/user_interactive.go
@@ -178,12 +178,6 @@ func (u *UserInteractive) Challenge(sessionID string) *util.JSONResponse {
 			// If an auth flow has params,
 			// send it as part of the challenge.
 			paramsCopy[key] = p
-
-			// If an auth flow generated a nonce, add it to the session.
-			nonce := getAuthParamNonce(p)
-			if nonce != "" {
-				u.Sessions[sessionID] = append(u.Sessions[sessionID], nonce)
-			}
 		}
 	}
 
@@ -287,12 +281,4 @@ func GetAuthParams(params interface{}) interface{} {
 		return p
 	}
 	return nil
-}
-
-func getAuthParamNonce(p interface{}) string {
-	v, ok := p.(config.AuthParams)
-	if ok {
-		return v.GetNonce()
-	}
-	return ""
 }

--- a/clientapi/routing/register_publickey_test.go
+++ b/clientapi/routing/register_publickey_test.go
@@ -340,7 +340,6 @@ func TestNewRegistrationSession(t *testing.T) {
 		"[object]")
 	ethParams := params.(config.EthereumAuthParams)
 	assert.NotEmptyf(ethParams.ChainIDs, "ChainIDs actual: empty, expected not empty")
-	assert.NotEmptyf(ethParams.Nonce, "Nonce actual: \"\", expected: not empty")
 	assert.NotEmptyf(ethParams.Version, "Version actual: \"\", expected: not empty")
 }
 

--- a/setup/config/config_publickey.go
+++ b/setup/config/config_publickey.go
@@ -1,35 +1,23 @@
 package config
 
 import (
-	"math/rand"
-	"time"
-
 	"github.com/matrix-org/dendrite/clientapi/auth/authtypes"
 )
 
-var nonceLength = 32
-
 type AuthParams interface {
 	GetParams() interface{}
-	GetNonce() string
 }
 
 type EthereumAuthParams struct {
-	Version  uint   `json:"version"`
-	ChainIDs []int  `json:"chain_ids"`
-	Nonce    string `json:"nonce"`
+	Version  uint  `json:"version"`
+	ChainIDs []int `json:"chain_ids"`
 }
 
 func (p EthereumAuthParams) GetParams() interface{} {
 	copyP := p
 	copyP.ChainIDs = make([]int, len(p.ChainIDs))
 	copy(copyP.ChainIDs, p.ChainIDs)
-	copyP.Nonce = newNonce(nonceLength)
 	return copyP
-}
-
-func (p EthereumAuthParams) GetNonce() string {
-	return p.Nonce
 }
 
 type EthereumAuthConfig struct {
@@ -61,23 +49,9 @@ func (pk *PublicKeyAuthentication) GetPublicKeyRegistrationParams() map[string]i
 		p := EthereumAuthParams{
 			Version:  pk.Ethereum.Version,
 			ChainIDs: pk.Ethereum.ChainIDs,
-			Nonce:    "",
 		}
 		params[authtypes.LoginTypePublicKeyEthereum] = p
 	}
 
 	return params
-}
-
-const lettersAndNumbers = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
-
-func newNonce(n int) string {
-	nonce := make([]byte, n)
-	rand.Seed(time.Now().UnixNano())
-
-	for i := range nonce {
-		nonce[i] = lettersAndNumbers[rand.Int63()%int64(len(lettersAndNumbers))]
-	}
-
-	return string(nonce)
 }


### PR DESCRIPTION
Remove nonce generation for EIP4361 sign-in. Client should use public library to create its sign-in message, which should include a nonce. No need for the server to generate one.

Signed-off-by: `Tak Wai Wong <tak@hntlabs.com>`
