### PR TITLE
Fix for `sql: converting argument $1 type: unsupported type []interface {}, a slice of interface` in new notifications select

### DIFF
--- a/syncapi/storage/sqlite3/notification_data_table.go
+++ b/syncapi/storage/sqlite3/notification_data_table.go
@@ -90,8 +90,8 @@ func (r *notificationDataStatements) SelectUserUnreadCountsForRooms(
 	for i := range roomIDs {
 		params[i+1] = roomIDs[i]
 	}
-	sql := strings.Replace(selectUserUnreadNotificationsForRooms, "($1)", sqlutil.QueryVariadic(len(params)), 1)
-	rows, err := r.db.QueryContext(ctx, sql, params)
+	sql := strings.Replace(selectUserUnreadNotificationsForRooms, "($2)", sqlutil.QueryVariadicOffset(len(roomIDs), 1), 1)
+	rows, err := r.db.QueryContext(ctx, sql, params...)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
The sqlite3 version was just not working, original pr here: https://github.com/matrix-org/dendrite/pull/2688

signed off by: austin ellis <austin@hntlabs.com>