### PR TITLE
Support environment variables for selected config fields

### DIFF
--- a/setup/config/config.go
+++ b/setup/config/config.go
@@ -23,8 +23,10 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"strconv"
 	"strings"
 
+	"github.com/joho/godotenv"
 	"github.com/matrix-org/dendrite/clientapi/auth/authtypes"
 	"github.com/matrix-org/dendrite/internal/mapsutil"
 	"github.com/matrix-org/gomatrixserverlib"
@@ -275,6 +277,9 @@ func LoadMatrixKey(privateKeyPath string, readFile func(string) ([]byte, error))
 // Derive generates data that is derived from various values provided in
 // the config file.
 func (config *Dendrite) Derive() error {
+	// Replace selected config with env variables.
+	config.replaceWithEnvVariables()
+
 	// Determine registrations flows based off config values
 
 	config.Derived.Registration.Params = make(map[string]interface{})
@@ -558,6 +563,55 @@ func (config *Dendrite) SetupTracing(serviceName string) (closer io.Closer, err 
 		jaegerconfig.Logger(logrusLogger{logrus.StandardLogger()}),
 		jaegerconfig.Metrics(jaegermetrics.NullFactory),
 	)
+}
+
+/*
+*
+Replace selected config with environment variables
+*/
+
+func (config *Dendrite) replaceWithEnvVariables() {
+	// Load .env
+	godotenv.Load()
+
+	// Replace selected fields with env variables
+	config.Global.ServerName = gomatrixserverlib.ServerName(
+		replaceWithEnvVariables(string(config.Global.ServerName)),
+	)
+	config.Global.DatabaseOptions.ConnectionString = DataSource(
+		replaceWithEnvVariables(
+			string(config.Global.DatabaseOptions.ConnectionString),
+		),
+	)
+
+	// Convert the deployment chain IDs from env variable into []int
+	// and replace the ChainIDs field.
+	deploymentChainIDs := replaceWithEnvVariables(config.ClientAPI.PublicKeyAuthentication.Ethereum.DeploymentChainIDs)
+	chainIds := strings.Split(deploymentChainIDs, ",")
+	if len(chainIds) > 0 && chainIds[0] != "" {
+		var ids []int
+		for _, id := range chainIds {
+			id, err := strconv.Atoi(strings.TrimSpace(id))
+			if err == nil {
+				ids = append(ids, id)
+			}
+		}
+		config.ClientAPI.PublicKeyAuthentication.Ethereum.ChainIDs = ids
+	}
+}
+
+var regexpEnvVariables = regexp.MustCompile(`\$\{(?P<Var>\w+)\}`)
+var varIndex = regexpEnvVariables.SubexpIndex("Var")
+
+func replaceWithEnvVariables(value string) string {
+	matches := regexpEnvVariables.FindAllStringSubmatch(value, -1)
+	for _, m := range matches {
+		if varIndex < len(m) {
+			envValue := os.Getenv(m[varIndex])
+			value = strings.ReplaceAll(value, fmt.Sprintf("${%s}", m[varIndex]), envValue)
+		}
+	}
+	return value
 }
 
 // logrusLogger is a small wrapper that implements jaeger.Logger using logrus.

--- a/setup/config/config_publickey.go
+++ b/setup/config/config_publickey.go
@@ -21,10 +21,11 @@ func (p EthereumAuthParams) GetParams() interface{} {
 }
 
 type EthereumAuthConfig struct {
-	Enabled     bool  `yaml:"enabled"`
-	Version     uint  `yaml:"version"`
-	ChainIDs    []int `yaml:"chain_ids"`
-	EnableAuthz bool  `yaml:"enable_authz"` // Flag to enable / disable authorization during development
+	Enabled            bool   `yaml:"enabled"`
+	Version            uint   `yaml:"version"`
+	ChainIDs           []int  `yaml:"chain_ids"`
+	DeploymentChainIDs string `yaml:"deployment_chain_ids"` // For deployment: use env variable strings to override the chain IDs.
+	EnableAuthz        bool   `yaml:"enable_authz"`         // Flag to enable / disable authorization during development
 }
 
 type PublicKeyAuthentication struct {

--- a/zion/zion_authorization.go
+++ b/zion/zion_authorization.go
@@ -56,11 +56,13 @@ func (za *ZionAuthorization) IsAllowed(args authorization.AuthorizationArgs) (bo
 		Name: args.Permission,
 	}
 
+	// Figure out whether this roomId is a "space" or a "channel"
+
 	switch userIdentifier.chainId {
 	case 1337, 31337:
-		return za.IsAllowedLocalhost(args.RoomId, userIdentifier.accountAddress, permission)
+		return za.isAllowedLocalhost(args.RoomId, userIdentifier.accountAddress, permission)
 	case 5:
-		return za.IsAllowedGoerli(args.RoomId, userIdentifier.accountAddress, permission)
+		return za.isAllowedGoerli(args.RoomId, userIdentifier.accountAddress, permission)
 	default:
 		log.Errorf("Unsupported chain id: %d\n", userIdentifier.chainId)
 	}
@@ -68,7 +70,7 @@ func (za *ZionAuthorization) IsAllowed(args authorization.AuthorizationArgs) (bo
 	return false, nil
 }
 
-func (za *ZionAuthorization) IsAllowedLocalhost(roomId string, user common.Address, permission DataTypesPermission) (bool, error) {
+func (za *ZionAuthorization) isAllowedLocalhost(roomId string, user common.Address, permission DataTypesPermission) (bool, error) {
 	if za.spaceManagerLocalhost != nil {
 		spaceId, err := za.spaceManagerLocalhost.GetSpaceIdByNetworkId(nil, roomId)
 		if err != nil {
@@ -93,7 +95,7 @@ func (za *ZionAuthorization) IsAllowedLocalhost(roomId string, user common.Addre
 	return false, nil
 }
 
-func (za *ZionAuthorization) IsAllowedGoerli(roomId string, user common.Address, permission DataTypesPermission) (bool, error) {
+func (za *ZionAuthorization) isAllowedGoerli(roomId string, user common.Address, permission DataTypesPermission) (bool, error) {
 	if za.spaceManagerGoerli != nil {
 		spaceId, err := za.spaceManagerGoerli.GetSpaceIdByNetworkId(nil, roomId)
 		if err != nil {

--- a/zion/zion_authorization.go
+++ b/zion/zion_authorization.go
@@ -56,13 +56,11 @@ func (za *ZionAuthorization) IsAllowed(args authorization.AuthorizationArgs) (bo
 		Name: args.Permission,
 	}
 
-	// Figure out whether this roomId is a "space" or a "channel"
-
 	switch userIdentifier.chainId {
 	case 1337, 31337:
-		return za.isAllowedLocalhost(args.RoomId, userIdentifier.accountAddress, permission)
+		return za.IsAllowedLocalhost(args.RoomId, userIdentifier.accountAddress, permission)
 	case 5:
-		return za.isAllowedGoerli(args.RoomId, userIdentifier.accountAddress, permission)
+		return za.IsAllowedGoerli(args.RoomId, userIdentifier.accountAddress, permission)
 	default:
 		log.Errorf("Unsupported chain id: %d\n", userIdentifier.chainId)
 	}
@@ -70,7 +68,7 @@ func (za *ZionAuthorization) IsAllowed(args authorization.AuthorizationArgs) (bo
 	return false, nil
 }
 
-func (za *ZionAuthorization) isAllowedLocalhost(roomId string, user common.Address, permission DataTypesPermission) (bool, error) {
+func (za *ZionAuthorization) IsAllowedLocalhost(roomId string, user common.Address, permission DataTypesPermission) (bool, error) {
 	if za.spaceManagerLocalhost != nil {
 		spaceId, err := za.spaceManagerLocalhost.GetSpaceIdByNetworkId(nil, roomId)
 		if err != nil {
@@ -95,7 +93,7 @@ func (za *ZionAuthorization) isAllowedLocalhost(roomId string, user common.Addre
 	return false, nil
 }
 
-func (za *ZionAuthorization) isAllowedGoerli(roomId string, user common.Address, permission DataTypesPermission) (bool, error) {
+func (za *ZionAuthorization) IsAllowedGoerli(roomId string, user common.Address, permission DataTypesPermission) (bool, error) {
 	if za.spaceManagerGoerli != nil {
 		spaceId, err := za.spaceManagerGoerli.GetSpaceIdByNetworkId(nil, roomId)
 		if err != nil {


### PR DESCRIPTION
For deployment purposes, secrets/keys and per-node settings should not be "hardcoded" in dendrite.yaml. Add config changes to derive / replace these settings with env variable values.

Signed-off-by: `Tak Wai Wong <tak@hntlabs.com>`
